### PR TITLE
obs: add patch and plugin

### DIFF
--- a/home/maximum.nix
+++ b/home/maximum.nix
@@ -29,7 +29,33 @@
   programs.firefox.enable = true;
   # added as firefox broken on nvidia 555
   programs.chromium.enable = true;
-  programs.obs-studio.enable = true;
+
+  programs.obs-studio = {
+    enable = true;
+
+    package = pkgs.obs-studio.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        (pkgs.fetchpatch {
+          name = "webrtc-pacing-handler";
+          url = "https://patch-diff.githubusercontent.com/raw/obsproject/obs-studio/pull/10966.patch";
+          hash = "sha256-VKNA0N4JHat/tLSRk3CLY+NcHsIoIvRHYfHo572KSGk=";
+        })
+      ];
+    });
+
+    plugins = [
+      (pkgs.obs-studio-plugins.obs-pipewire-audio-capture.overrideAttrs {
+        version = "2024-09-04";
+        src = pkgs.fetchFromGitHub {
+          owner = "dimtpap";
+          repo = "obs-pipewire-audio-capture";
+          rev = "38176824e5f95f5e2542130f6d7c027ea64536c4";
+          sha256 = "sha256-z1eHz5uxfwfauO0zB/mMxzRmte5UYKGwsi3CkQu5Vhc=";
+        };
+        cmakeFlags = [ ];
+      })
+    ];
+  };
 
   programs.mpv = {
     enable = true;


### PR DESCRIPTION
Patch fixes stutter when streaming over broadcast box and plugin allows for excluding specific applications from audio capture.