### PR TITLE
nvidia: use open kernel modules

### DIFF
--- a/modules/hardware/nvidia.nix
+++ b/modules/hardware/nvidia.nix
@@ -12,8 +12,7 @@
     package = config.boot.kernelPackages.nvidiaPackages.stable;
     # Major issues if this is disabled
     modesetting.enable = true;
-    # Eventually enable this
-    open = false;
+    open = true;
     nvidiaSettings = false;
   };
 


### PR DESCRIPTION
Since 560 is now stable we should use the open kernel modules